### PR TITLE
Changed outlineDimension to a property

### DIFF
--- a/KSLabel/KSLabel.h
+++ b/KSLabel/KSLabel.h
@@ -38,7 +38,7 @@
 
 @property BOOL drawOutline;
 @property (strong, nonatomic) UIColor *outlineColor;
-
+@property (nonatomic) CGFloat outlineDimension;
 @property BOOL drawGradient;
 -(void) setGradientColors: (CGFloat [8]) colors;
 @end

--- a/KSLabel/KSLabel.m
+++ b/KSLabel/KSLabel.m
@@ -98,7 +98,7 @@
 		alphaMask = CGBitmapContextCreateImage(context);
 		
 		// Outline width
-		CGContextSetLineWidth(context, 4);
+		CGContextSetLineWidth(context, self.outlineDimension);
 		CGContextSetLineJoin(context, kCGLineJoinRound);
 		
 		// Set the drawing method to stroke


### PR DESCRIPTION
it's possible to change the dimension of outlined border by setting:

mylabel.outlineDimension = aCGFloatValue;

then call normally 
[myLabel setDrawOutline:YES];
